### PR TITLE
feat: Allow functions to override the Mappers

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ var getCombinedUrlState = function (previousState, newUrlState) {
   return combinedUrlState
 }
 
-var initializedReactUrlState = function (options) {
+var initializedReactUrlState = function (options, callback) {
   var context = this;
   if (options == null) {
     throw 'No options defined in initializeReactUrlState! ' +
@@ -100,7 +100,7 @@ var initializedReactUrlState = function (options) {
   }
 
   var setUrlState = function (urlState, callback) {
-    if(options.debug) { console.log('react-url-state: setting state: ', urlState); }
+    if(options.debug) { console.log('react-url-state: setting state: ', urlState, ' callback: ', callback); }
     context.setState(urlState, function () {
       var urlStateWithPreviousState = getCombinedUrlState(queryString.parse(history.location.search), urlState);
       let pathname = options.pathname || window.location.pathname;
@@ -118,7 +118,7 @@ var initializedReactUrlState = function (options) {
   });
 
   if(options.debug) { console.log('react-url-state: getting id resolver promises..'); }
-  getIdResolverPromise(urlState, options.fromIdResolvers).then(setUrlState);
+  getIdResolverPromise(urlState, options.fromIdResolvers).then(newState => setUrlState(newState, callback));
 
   return {
     setUrlState: setUrlState

--- a/index.js
+++ b/index.js
@@ -118,7 +118,15 @@ var initializedReactUrlState = function (options, callback) {
   });
 
   if(options.debug) { console.log('react-url-state: getting id resolver promises..'); }
-  getIdResolverPromise(urlState, options.fromIdResolvers).then(newState => setUrlState(newState, callback));
+
+  getIdResolverPromise(urlState, options.fromIdResolvers).then(newState => {
+    if(options.leavestate === true) {
+      callback.apply(context, [newState]);
+    } else {
+      setUrlState(newState, callback)
+    }
+  });
+
 
   return {
     setUrlState: setUrlState

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var createHistory = require('history/createBrowserHistory').default;
+var createBrowserHistory = require('history/createBrowserHistory').default;
+var createMemoryHistory = require('history/createMemoryHistory').default;
 var queryString = require('./query-string');
 
-var history = createHistory();
+const history = typeof window !== 'undefined' ? createBrowserHistory() : createMemoryHistory();
 
 var isPrimitiveType = function (a) {
   return typeof a === 'string' || typeof a === 'number' || typeof a === 'boolean';


### PR DESCRIPTION
This change allows fromIdMappers and toIdMappers to be set to functions
instead of maps of functions. This allows complex state objects to be
stored as readble URL parameters with dynamic names.

For example:
```
state = {
  filters[
    { type: Brand, value: foo },
    { type: Device, value: var }
  ]
}
```
Renders as: http://localhost:8000/?filter0Brand=foo&filter1Device=bar

```
const reactUrlStateOptions = {
  fromIdResolvers: async (param, value, oldState) => {
    let newState = { ...oldState }
    let found = param.match(/filter(\d+)([A-Za-z].+)/)
    if (found !== null) {
      let fId = parseInt(found[1], 10)
      if (newState.filters === undefined) {
        newState.filters = new Array(fId + 1)
      } else {
        while (newState.filters.length < fId + 1) {
          newState.filters.push({})
        }
      }
      newState.filters[fId] = { type: found[2], value: value }
    }
    return newState
  },
  toIdMappers: (param, state) => {
    if (param === `filters`) {
      return state.filters
        .map((f, i) => {
          if (typeof f.toUrl === `function`) {
            return `filter${i}${f.type}=${f.value)}`
          }
          return undefined
        })
        .filter(p => p !== undefined && p !== null)
        .join(`&`)
    }
  },
  pathname: `/`,
}
```