### PR TITLE
Fixing bug #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,8 +92,9 @@ var initializedReactUrlState = function (options) {
   var setUrlState = function (urlState, callback) {
     if(options.debug) { console.log('react-url-state: setting state: ', urlState); }
     context.setState(urlState, function () {
-      var urlStateWithPreviousState = getCombinedUrlState(queryString.parse(history.location.search), urlState)
-      history.push(convertToHistory(urlStateWithPreviousState, options.pathname, options.toIdMappers));
+      var urlStateWithPreviousState = getCombinedUrlState(queryString.parse(history.location.search), urlState);
+      let pathname = options.pathname || window.location.pathname;
+      history.push(convertToHistory(urlStateWithPreviousState, pathname, options.toIdMappers));
       if (typeof callback === 'function') {
         callback.apply(context);
       }


### PR DESCRIPTION
With this change you can use the same state among various pages.

Note for whomever stumbles into this: if you're using Router you'll have to call a dummy "setUrlState" from each child's `onComponentDidMount` so you make react-url-state update the browser's URL (and you'll have to check not to run that except on first load or you'll hit recursion limit instantly).